### PR TITLE
Language direction flag

### DIFF
--- a/td/admin.py
+++ b/td/admin.py
@@ -11,6 +11,7 @@ admin.site.register(
         "two_letter",
         "three_letter",
         "native_name",
+        "direction",
         "comment",
         "created_at",
         "updated_at",

--- a/td/migrations/0002_additionallanguage_direction.py
+++ b/td/migrations/0002_additionallanguage_direction.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('td', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='additionallanguage',
+            name='direction',
+            field=models.CharField(default=b'l', max_length=1, choices=[(b'l', b'ltr'), (b'r', b'rtl')]),
+            preserve_default=True,
+        ),
+    ]

--- a/td/models.py
+++ b/td/models.py
@@ -5,11 +5,16 @@ from django.utils.encoding import python_2_unicode_compatible
 
 @python_2_unicode_compatible
 class AdditionalLanguage(models.Model):
+    DIRECTION_CHOICES = (
+        ("l", "ltr"),
+        ("r", "rtl")
+    )
     ietf_tag = models.CharField(max_length=100)
     common_name = models.CharField(max_length=100)
     two_letter = models.CharField(max_length=2, blank=True)
     three_letter = models.CharField(max_length=3, blank=True)
     native_name = models.CharField(max_length=100, blank=True)
+    direction = models.CharField(max_length=1, choices=DIRECTION_CHOICES, default="l")
     comment = models.TextField(blank=True)
     created_at = models.DateTimeField(default=timezone.now)
     updated_at = models.DateTimeField(default=timezone.now)

--- a/td/receivers.py
+++ b/td/receivers.py
@@ -19,6 +19,7 @@ def handle_additionallanguage_save(sender, instance, **kwargs):
     a_code = instance.merge_code()
     lang, created = Language.objects.get_or_create(code=a_code)
     lang.name = instance.merge_name()
+    lang.direction = instance.direction
     lang.save()
 
 

--- a/td/templates/td/additionallanguage_list.html
+++ b/td/templates/td/additionallanguage_list.html
@@ -13,6 +13,7 @@
             <th>Three Letter</th>
             <th>Common Name</th>
             <th>Native Name</th>
+            <th>Direction</th>
             <th>Comment</th>
         </tr>
     </thead>

--- a/td/templates/uw/language_list.html
+++ b/td/templates/uw/language_list.html
@@ -10,6 +10,7 @@
                 <tr>
                     <th>Code</th>
                     <th>Name</th>
+                    <th>Direction</th>
                     <th>Country</th>
                     <th># Native Speakers</th>
                     <th>Gateway Language</th>

--- a/td/tests/test_models.py
+++ b/td/tests/test_models.py
@@ -78,14 +78,17 @@ class LanguageIntegrationTests(TestCase):
         self.assertEquals(langs["aa"]["cc"], ["ET"])
         self.assertEquals(langs["aa"]["ln"], "Afaraf")
         self.assertEquals(langs["aa"]["lr"], "Africa")
+        self.assertEquals(langs["aa"]["ld"], "ltr")
         self.assertTrue("kmg" in langs)
         self.assertEquals(langs["kmg"]["cc"], ["PG"])
         self.assertEquals(langs["kmg"]["ln"], u"K\xe2te")
         self.assertEquals(langs["kmg"]["lr"], "Pacific")
+        self.assertEquals(langs["kmg"]["ld"], "ltr")
         self.assertTrue("es-419" in langs)
         self.assertEquals(langs["es-419"]["cc"], [""])
         self.assertEquals(langs["es-419"]["ln"], u"Espa\xf1ol Latin America")
         self.assertEquals(langs["es-419"]["lr"], "")
+        self.assertEquals(langs["es-419"]["ld"], "ltr")
 
     def test_add_and_delete_from_additionallanguage(self):
         additional = AdditionalLanguage.objects.create(
@@ -99,3 +102,17 @@ class LanguageIntegrationTests(TestCase):
         additional.delete()
         data = Language.names_text().split("\n")
         self.assertTrue("zzz-z-test\tZTest" not in data)
+
+    def test_additionallanguage_direction(self):
+        additional = AdditionalLanguage.objects.create(
+            ietf_tag="zzz-r-test",
+            common_name="ZRTest",
+            direction="r"
+        )
+        additional.save()
+        langnames = Language.names_text().split("\n")
+        self.assertTrue("zzz-r-test\tZRTest" in langnames)
+        data = json.loads(json.dumps(Language.names_data()))
+        langs = {x["lc"]: x for x in data}
+        self.assertTrue("zzz-r-test" in langs)
+        self.assertEquals(langs["zzz-r-test"]["ld"], "rtl")

--- a/td/uw/admin.py
+++ b/td/uw/admin.py
@@ -32,7 +32,7 @@ class CountryAdmin(EntryTrackingAdmin):
 
 
 class LanguageAdmin(EntryTrackingAdmin):
-    list_display = ["code", "name", "gateway_language", "native_speakers"]
+    list_display = ["code", "name", "gateway_language", "direction", "native_speakers"]
 
     def get_readonly_fields(self, request, obj=None):
         if obj:

--- a/td/uw/forms.py
+++ b/td/uw/forms.py
@@ -87,6 +87,7 @@ class LanguageForm(EntityTrackingForm):
         fields = [
             "code",
             "name",
+            "direction",
             "gateway_language",
             "native_speakers",
             "networks_translating"

--- a/td/uw/migrations/0002_language_direction.py
+++ b/td/uw/migrations/0002_language_direction.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('uw', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='language',
+            name='direction',
+            field=models.CharField(default=b'l', max_length=1, choices=[(b'l', b'ltr'), (b'r', b'rtl')]),
+            preserve_default=True,
+        ),
+    ]

--- a/td/uw/models.py
+++ b/td/uw/models.py
@@ -122,6 +122,10 @@ tree = {
 
 @python_2_unicode_compatible
 class Language(models.Model):
+    DIRECTION_CHOICES = (
+        ("l", "ltr"),
+        ("r", "rtl")
+    )
     code = models.CharField(max_length=100, unique=True)
     name = models.CharField(max_length=100, blank=True)
     country = models.ForeignKey(Country, null=True, blank=True)
@@ -129,6 +133,7 @@ class Language(models.Model):
     native_speakers = models.IntegerField(null=True, blank=True)
     networks_translating = models.ManyToManyField(Network, null=True, blank=True)
     gateway_flag = models.BooleanField(default=False, blank=True, db_index=True)
+    direction = models.CharField(max_length=1, choices=DIRECTION_CHOICES, default="l")
 
     tracker = FieldTracker()
 
@@ -172,7 +177,7 @@ class Language(models.Model):
     @classmethod
     def names_data(cls):
         return [
-            dict(lc=x.lc, ln=x.ln, cc=[x.cc], lr=x.lr, gw=x.gateway_flag)
+            dict(lc=x.lc, ln=x.ln, cc=[x.cc], lr=x.lr, gw=x.gateway_flag, ld=x.get_direction_display())
             for x in cls.objects.all().order_by("code")
         ]
 

--- a/td/uw/views.py
+++ b/td/uw/views.py
@@ -164,6 +164,7 @@ class AjaxLanguageListView(DataTableSourceView):
     fields = [
         "code",
         "name",
+        "direction",
         "country__name",
         "native_speakers",
         "gateway_language__name",

--- a/td/views.py
+++ b/td/views.py
@@ -97,6 +97,7 @@ class AjaxAdditionalLanguageListView(DataTableSourceView):
         "three_letter",
         "common_name",
         "native_name",
+        "direction",
         "comment"
     ]
 


### PR DESCRIPTION
- adds a new direction flag to both uw.Language and td.AdditionalLanguage
- implemented as a single character field (in case there needs to be a 3rd or 4th valid option)
- implemented using choices and descriptions of "ltr" and "rtl" for "l" and "r" respectively
- test on additional language and language output
- outputs "ld": "ltr" or "ld": "rtl" in the json export view
- defaults to "l" ("ltr") as part of the migrations
- there is currently no imported data source to provide the data, so this is just the initial step in supporting language direction
- the admin and uw views should all now support the direction field(s) as well
