### PR TITLE
Iso 639 3 codes

### DIFF
--- a/td/receivers.py
+++ b/td/receivers.py
@@ -20,6 +20,7 @@ def handle_additionallanguage_save(sender, instance, **kwargs):
     lang, created = Language.objects.get_or_create(code=a_code)
     lang.name = instance.merge_name()
     lang.direction = instance.direction
+    lang.iso_639_3 = instance.three_letter
     lang.save()
 
 

--- a/td/templates/uw/language_list.html
+++ b/td/templates/uw/language_list.html
@@ -9,6 +9,7 @@
             <thead>
                 <tr>
                     <th>Code</th>
+                    <th>ISO-639-3</th>
                     <th>Name</th>
                     <th>Direction</th>
                     <th>Country</th>

--- a/td/tests/test_models.py
+++ b/td/tests/test_models.py
@@ -90,6 +90,17 @@ class LanguageIntegrationTests(TestCase):
         self.assertEquals(langs["es-419"]["lr"], "")
         self.assertEquals(langs["es-419"]["ld"], "ltr")
 
+    def test_three_letter_field(self):
+        additional = AdditionalLanguage(
+            two_letter="z3",
+            common_name="ZTest of 3 Letters",
+            three_letter="z3z",
+            ietf_tag="z3-test"
+        )
+        additional.save()
+        lang = Language.objects.get(code="z3")
+        self.assertEquals(lang.iso_639_3, additional.three_letter)
+
     def test_add_and_delete_from_additionallanguage(self):
         additional = AdditionalLanguage.objects.create(
             ietf_tag="zzz-z-test",

--- a/td/uw/forms.py
+++ b/td/uw/forms.py
@@ -86,6 +86,7 @@ class LanguageForm(EntityTrackingForm):
         model = Language
         fields = [
             "code",
+            "iso_639_3",
             "name",
             "direction",
             "gateway_language",

--- a/td/uw/migrations/0003_language_iso_639_3.py
+++ b/td/uw/migrations/0003_language_iso_639_3.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('uw', '0002_language_direction'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='language',
+            name='iso_639_3',
+            field=models.CharField(default=b'', max_length=3, db_index=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/td/uw/models.py
+++ b/td/uw/models.py
@@ -134,6 +134,7 @@ class Language(models.Model):
     networks_translating = models.ManyToManyField(Network, null=True, blank=True)
     gateway_flag = models.BooleanField(default=False, blank=True, db_index=True)
     direction = models.CharField(max_length=1, choices=DIRECTION_CHOICES, default="l")
+    iso_639_3 = models.CharField(max_length=3, default="", db_index=True, blank=True, verbose_name="ISO-639-3")
 
     tracker = FieldTracker()
 

--- a/td/uw/views.py
+++ b/td/uw/views.py
@@ -163,6 +163,7 @@ class AjaxLanguageListView(DataTableSourceView):
     model = Language
     fields = [
         "code",
+        "iso_639_3",
         "name",
         "direction",
         "country__name",


### PR DESCRIPTION
- added iso_639_3 field to uw.language
- updated integrate_imports to pull it in from appropriate source
- added to test_models
- changed IMB resource update to use ROL field to match to the new iso_639_3 (with fallback to "code" if not found)
- display the iso_639_3 field on update form and language list (ajax) view
