### PR TITLE
added new country gateway_language to detail view and update form

### DIFF
--- a/td/templates/uw/country_detail.html
+++ b/td/templates/uw/country_detail.html
@@ -13,7 +13,15 @@
     {% endif %}
 </h1>
 
+
+
 <div class="row">
+    <div class="col-md-4">
+        <table class="table">
+            <thead><tr><th>Gateway Language</th></tr></thead>
+            <tbody><tr><td>{% if country.gateway_language %}{{ country.gateway_language.name }} ({{ country.gateway_language.code }}){% else %}None{% endif %}</td></tr></tbody>
+        </table>
+    </div>
     <div class="col-md-4">
         <table class="table">
             <thead><tr><th>Population</th></tr></thead>

--- a/td/uw/models.py
+++ b/td/uw/models.py
@@ -46,6 +46,12 @@ class Country(models.Model):
 
     tracker = FieldTracker()
 
+    def gateway_language(self):
+        if "gateway_language" in self.extra_data:
+            return next(iter(Language.objects.filter(code=self.extra_data["gateway_language"])), None)
+        else:
+            return None
+
     @classmethod
     def regions(cls):
         qs = cls.objects.all().values_list("region", flat=True).distinct()


### PR DESCRIPTION
* added "Gateway Language" to detail view of Country per uW request
* also added ability to select a new Gateway Language for the country via the form using the language selection widget
** this was interesting since "gateway_language" on country is actually just a json attribute in the new extra_data JSON field on the model. So it's a wrapper field in the form that makes it seem like a native part of the Country model
* created a gateway_language helper method on the Country model to make it easy to access the gateway_language in template code and other places.