### PR TITLE
fixed language search to 'prefer' language code starts-with style search...

### DIFF
--- a/td/views.py
+++ b/td/views.py
@@ -45,18 +45,24 @@ def languages_autocomplete(request):
     if len(term) <= 3:
         term = term.encode("utf-8")
         # search: cc, lc
+        # first do a *starts with* style search of language code (lc)
         d.extend([
             x
             for x in data
-            if term in x["lc"].lower() or term in [y.lower() for y in x["cc"]]
+            if term == x["lc"].lower()[:len(term)]
+        ])
+        d.extend([
+            x
+            for x in data
+            if term in [y.lower() for y in x["cc"]]
         ])
     if len(term) >= 3:
-        # search: ln, lr
+        # search: lc, ln, lr
         term = term.encode("utf-8")
         d.extend([
             x
             for x in data
-            if term in x["ln"].lower() or term in x["lr"].lower()
+            if term in x["lc"] or term in x["ln"].lower() or term in x["lr"].lower()
         ])
     return JsonResponse({"results": d, "count": len(d), "term": term})
 


### PR DESCRIPTION
- basically I have it trying to match the language code "starts-with" style first.
- then it separately extends based on country code (if the length is 3 or less)
- if the length is 3 or more it tries to then extend by language code (in case they are trying to enter something like es-419) and then also language name or region). Virtually unchanged from before but I added the language-code in case of es-419.

This seems to solve the problem for now. But I could see further breaking this down in terms of order instead of just lots of "or" statements which won't order the results.