### PR TITLE
Language search filter

### DIFF
--- a/td/uw/views.py
+++ b/td/uw/views.py
@@ -2,11 +2,14 @@ from django.core.urlresolvers import reverse
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import ListView, CreateView, UpdateView, DetailView, TemplateView
+from django.db.models import Q
 from django.contrib import messages
 
 from account.decorators import login_required
 from account.mixins import LoginRequiredMixin
 from eventlog.models import log
+
+import operator
 
 from .forms import (
     CountryForm,
@@ -226,11 +229,38 @@ class CountryEditView(LoginRequiredMixin, EventLogMixin, EntityTrackingMixin, Up
         return reverse("country_detail", args=[self.object.pk])
 
 
+class LanguageTableSourceView(DataTableSourceView):
+
+    def __init__(self, **kwargs):
+        super(LanguageTableSourceView, self).__init__(**kwargs)
+
+    @property
+    def filtered_data(self):
+        if len(self.search_term) <= 3:
+            qs = self.queryset.filter(
+                reduce(
+                    operator.or_,
+                    [Q(code__istartswith=self.search_term),
+                     Q(iso_639_3__istartswith=self.search_term)]
+                )
+            ).order_by("code")
+            if qs.count():
+                return qs
+        return self.queryset.filter(
+            reduce(
+                operator.or_,
+                [Q(x) for x in self.filter_predicates]
+            )
+        ).order_by(
+            self.order_by
+        )
+
+
 class LanguageListView(TemplateView):
     template_name = "uw/language_list.html"
 
 
-class AjaxLanguageListView(DataTableSourceView):
+class AjaxLanguageListView(LanguageTableSourceView):
     model = Language
     fields = [
         "code",

--- a/td/uw/views.py
+++ b/td/uw/views.py
@@ -240,8 +240,7 @@ class LanguageTableSourceView(DataTableSourceView):
             qs = self.queryset.filter(
                 reduce(
                     operator.or_,
-                    [Q(code__istartswith=self.search_term),
-                     Q(iso_639_3__istartswith=self.search_term)]
+                    [Q(code__istartswith=self.search_term)]
                 )
             ).order_by("code")
             if qs.count():


### PR DESCRIPTION
subclassed the DataTableSourceView to override the filtered_data property/method as a new LanguageTableSourceView. This uniquely handles searching for language codes if 3 or fewer characters are entered. And due to the requirement that "en" return first, the order (in this case) is forced to be by "code". 

Scenarios considered:
* code "en" entered
  * all language codes starting with "en" are returned
  * starts with "en" because we're sorting by "code"
* code "zh" entered
  * all language codes starting with "zh" are returned
  * starts with "zh" and the "zh-tw" as prescribed
  * if it weren't for this case, I was going to also include iso_639_3 as part of the special search, but za which has an iso 639-3 code of zha would then show up first when sorted by the shorter code "za"
* code "es" entered
  * "es" returned and followed by "es-419", etc...
* "english" entered
  * switches back to the old way so it uses the selected sorting and displays all languages with "english" contained within any of the fields
* "esp" entered
  * doesn't match any codes
  * falls over and does the default search instead which gets us "Esperanto, español and español Latin America" which is what I think we'd want it to do

Final thoughts:
* I considered some other methods to try to more comprehensively search and get things in a particular order, but this solution is the least intrusive and seems less risky than other more elaborate measures.
* I put a Q list in the special search like the original one because originally I was going to include ISO 639 3 in it and kept it there afterward for easier expansion in the future in case needs changed.
