### PR TITLE
Gateway seed

### DIFF
--- a/td/uw/management/commands/seed_gateway_languages.py
+++ b/td/uw/management/commands/seed_gateway_languages.py
@@ -1,0 +1,9 @@
+from django.core.management.base import BaseCommand
+from ...tasks import seed_languages_gateway_language
+
+
+class Command(BaseCommand):
+    help = "assign a gateway_language for languages that don't have one based on associated country"
+
+    def handle(self, *args, **options):
+        seed_languages_gateway_language()

--- a/td/uw/tasks.py
+++ b/td/uw/tasks.py
@@ -57,4 +57,3 @@ def seed_languages_gateway_language():
         if lang.country and lang.country.gateway_language():
             lang.gateway_language = lang.country.gateway_language()
             lang.save()
-

--- a/td/uw/tasks.py
+++ b/td/uw/tasks.py
@@ -50,3 +50,11 @@ def _process_obs_response(response):
 
 def update_obs_resources():
     _process_obs_response(_get_obs_api_data())
+
+
+def seed_languages_gateway_language():
+    for lang in Language.objects.filter(gateway_language=None, gateway_flag=False):
+        if lang.country and lang.country.gateway_language():
+            lang.gateway_language = lang.country.gateway_language()
+            lang.save()
+

--- a/td/uw/tests/test_seed_gateway.py
+++ b/td/uw/tests/test_seed_gateway.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from ..models import Language, Country
+from ..tasks import seed_languages_gateway_language
+
+class SeedGatewayTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        country1 = Country(code="c1", name="Country 1")
+        country1.extra_data = {"gateway_language": "gz1"}
+        country1.save()
+        country2 = Country(code="c2", name="Country 2")
+        country2.save()
+        lang1 = Language(code="gz1", name="Z Test 1", gateway_flag=True, gateway_language=None, country=country1)
+        lang1.save()
+        lang2 = Language(code="gz2", name="Z Test 2", gateway_flag=False, gateway_language=lang1, country=country2)
+        lang2.save()
+        lang3 = Language(code="gz3", name="Z Test 3", gateway_flag=False, gateway_language=None, country=country1)
+        lang3.save()
+        lang4 = Language(code="gz4", name="Z Test 4", gateway_flag=False, gateway_language=None, country=country2)
+        lang4.save()
+        lang5 = Language(code="gz5", name="Z Test 5", gateway_flag=False, gateway_language=None, country=None)
+        lang5.save()
+
+    def test_seed(self):
+        seed_languages_gateway_language()
+        z1 = Language.objects.get(code="gz1")
+        self.assertIsNone(z1.gateway_language)
+        self.assertEquals(Language.objects.get(code="gz2").gateway_language, z1)
+        self.assertEquals(Language.objects.get(code="gz3").gateway_language, z1)
+        self.assertIsNone(Language.objects.get(code="gz4").gateway_language)
+        self.assertIsNone(Language.objects.get(code="gz5").gateway_language)

--- a/td/uw/tests/test_seed_gateway.py
+++ b/td/uw/tests/test_seed_gateway.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from ..models import Language, Country
 from ..tasks import seed_languages_gateway_language
 
+
 class SeedGatewayTestCase(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/td/uw/views.py
+++ b/td/uw/views.py
@@ -236,7 +236,7 @@ class LanguageTableSourceView(DataTableSourceView):
 
     @property
     def filtered_data(self):
-        if len(self.search_term) <= 3:
+        if len(self.search_term) and len(self.search_term) <= 3:
             qs = self.queryset.filter(
                 reduce(
                     operator.or_,


### PR DESCRIPTION
* new management command to seed gateway languages
  * only sets the gateway_language for a language if:
    * it doesn't have a gateway_language
    * it isn't a gateway_language itself
    * it is assigned to a country
    * the country it is assigned to has a gateway_language
* fixed an issue with language search where a blank search value was interpreted as a code search and therefore only would sort based on language code
* issue note:
  * now that most languages have a gateway language the gateway language name becomes a possible match on language searches which is possibly desired or not desired. Not sure.
