### PR TITLE
Bugfix: notify_requestor_approved task passing user.id instead of user.

### DIFF
--- a/td/publishing/tasks.py
+++ b/td/publishing/tasks.py
@@ -5,6 +5,7 @@ import subprocess
 from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
+from django.contrib.auth.models import User
 
 from celery import task
 
@@ -66,6 +67,7 @@ def notify_requestor_rejected(request_id):
 
 def approve_publish_request(request_id, user_id):
     pr = PublishRequest.objects.get(pk=request_id)
-    oresource = pr.publish(by_user=user_id)
+    user = User.objects.get(pk=user_id)
+    oresource = pr.publish(by_user=user)
     notify_requestor_approved.delay(pr.pk)
     return oresource.pk

--- a/td/tests/publishing/test_models.py
+++ b/td/tests/publishing/test_models.py
@@ -1,0 +1,44 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from mock import patch
+
+from td.models import Language
+from td.publishing.models import (
+    OfficialResource, OfficialResourceType, PublishRequest)
+
+
+class PublishRequestTestCase(TestCase):
+
+    def setUp(self):
+        resource_type, _ = OfficialResourceType.objects.get_or_create(
+            short_name="obs",
+            long_name="OpenBibleStory"
+        )
+        language, _ = Language.objects.get_or_create(
+            code="en",
+            name="English"
+        )
+        source_language, _ = Language.objects.get_or_create(
+            code="arc",
+            name="Aramaic"
+        )
+        self.user, _ = User.objects.get_or_create(
+            first_name="Test",
+            last_name="RequestorUser",
+            username="test_requestor_user"
+        )
+        self.model, _ = PublishRequest.objects.get_or_create(
+            requestor="Test publish request",
+            resource_type=resource_type,
+            language=language,
+            checking_level=1,
+            source_text=source_language
+        )
+
+    @patch("td.publishing.models.OfficialResource.ingest")
+    def test_publish(self, mock_ingest):
+        resource = self.model.publish(by_user=self.user)
+        self.assertIsInstance(resource, OfficialResource)
+        self.assertEqual(resource.language.code, "en")
+        mock_ingest.assert_called_once_with()

--- a/td/tests/publishing/test_tasks.py
+++ b/td/tests/publishing/test_tasks.py
@@ -39,11 +39,15 @@ class PublishTasksTestCase(TestCase):
     @patch("td.publishing.tasks.PublishRequest.publish")
     @patch("td.publishing.tasks.notify_requestor_approved")
     def test_approve_publish_request(self, mock_task, mock_publish):
-        mock_publish.return_value = Mock(pk=self.user.id)
+        mock_publish.return_value = Mock(pk=1)
         resource_id = approve_publish_request(
             self.request.id,
             self.user.id
         )
-        self.assertEqual(resource_id, self.user.id)
+        # Assert that the resource.id was returned...
+        self.assertEqual(resource_id, 1)
+        # and that the PublishRequst.publish was called with the user object...
         mock_publish.assert_called_once_with(by_user=self.user)
+        # and the notify_requestor_approved celery task was called with the
+        # PublishRequest.id
         mock_task.delay.assert_called_once_with(self.request.id)

--- a/td/tests/publishing/test_tasks.py
+++ b/td/tests/publishing/test_tasks.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from mock import patch, Mock
+
+from td.models import Language
+from td.publishing.models import OfficialResourceType, PublishRequest
+from td.publishing.tasks import approve_publish_request
+
+
+class PublishTasksTestCase(TestCase):
+
+    def setUp(self):
+        resource_type, _ = OfficialResourceType.objects.get_or_create(
+            short_name="obs",
+            long_name="OpenBibleStory"
+        )
+        language, _ = Language.objects.get_or_create(
+            code="en",
+            name="English"
+        )
+        source_language, _ = Language.objects.get_or_create(
+            code="la",
+            name="Latin"
+        )
+        self.user, _ = User.objects.get_or_create(
+            first_name="Test",
+            last_name="RequestorUser",
+            username="test_requestor_user"
+        )
+        self.request, _ = PublishRequest.objects.get_or_create(
+            requestor="Test publish request",
+            resource_type=resource_type,
+            language=language,
+            checking_level=1,
+            source_text=source_language
+        )
+
+    @patch("td.publishing.tasks.PublishRequest.publish")
+    @patch("td.publishing.tasks.notify_requestor_approved")
+    def test_approve_publish_request(self, mock_task, mock_publish):
+        mock_publish.return_value = Mock(pk=self.user.id)
+        resource_id = approve_publish_request(
+            self.request.id,
+            self.user.id
+        )
+        self.assertEqual(resource_id, self.user.id)
+        mock_publish.assert_called_once_with(by_user=self.user)
+        mock_task.delay.assert_called_once_with(self.request.id)


### PR DESCRIPTION
Fixes bug where user.id was being passed to the notify_requestor_approved task instead of a user object.

* Adds unit tests for notify_requestor_approved task
* Adds unit test coverage for PublishRequest.publish

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/266)
<!-- Reviewable:end -->
