### PR TITLE
Adds anglicized_name to the Language model, populates from imports

### DIFF
--- a/td/forms.py
+++ b/td/forms.py
@@ -97,6 +97,7 @@ class LanguageForm(EntityTrackingForm):
             "code",
             "iso_639_3",
             "name",
+            "anglicized_name",
             "direction",
             "gateway_language",
             "native_speakers",

--- a/td/migrations/0002_language_anglicized_name.py
+++ b/td/migrations/0002_language_anglicized_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('td', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='language',
+            name='anglicized_name',
+            field=models.CharField(max_length=100, blank=True),
+        ),
+    ]

--- a/td/models.py
+++ b/td/models.py
@@ -145,6 +145,7 @@ class Language(models.Model):
     )
     code = models.CharField(max_length=100, unique=True)
     name = models.CharField(max_length=100, blank=True)
+    anglicized_name = models.CharField(max_length=100, blank=True)
     country = models.ForeignKey(Country, null=True, blank=True)
     gateway_language = models.ForeignKey("self", related_name="gateway_to", null=True, blank=True)
     native_speakers = models.IntegerField(null=True, blank=True)
@@ -182,6 +183,10 @@ class Language(models.Model):
     def ln(self):
         return self.name.encode("utf-8")
 
+    @property
+    def ang(self):
+        return self.anglicized_name
+
     @classmethod
     def codes_text(cls):
         return " ".join([
@@ -199,7 +204,7 @@ class Language(models.Model):
     @classmethod
     def names_data(cls):
         return [
-            dict(pk=x.pk, lc=x.lc, ln=x.ln, cc=[x.cc], lr=x.lr, gw=x.gateway_flag, ld=x.get_direction_display())
+            dict(pk=x.pk, lc=x.lc, ln=x.ln, ang=x.ang, cc=[x.cc], lr=x.lr, gw=x.gateway_flag, ld=x.get_direction_display())
             for x in cls.objects.all().order_by("code")
         ]
 

--- a/td/tasks.py
+++ b/td/tasks.py
@@ -8,25 +8,27 @@ from pinax.eventlog.models import log
 from td.imports.models import (
     EthnologueLanguageCode,
     EthnologueCountryCode,
+    IMBPeopleGroup,
     SIL_ISO_639_3,
-    WikipediaISOLanguage,
     WikipediaISOCountry,
-    IMBPeopleGroup
+    WikipediaISOLanguage
 )
-
 from td.resources.models import Title, Resource, Media
-from td.models import Region, Country, Language
 
-from .models import AdditionalLanguage
+from .models import AdditionalLanguage, Country, Language, Region
 from .signals import languages_integrated
 
 
 @task()
 def integrate_imports():
+    """
+    Integrate imported language data into the language model
+    """
     cursor = connection.cursor()
     cursor.execute("""
 select coalesce(nullif(x.part_1, ''), x.code) as code,
        coalesce(nullif(nn1.native_name, ''), nullif(nn2.native_name, ''), x.ref_name) as name,
+       coalesce(nullif(nn1.language_name, ''), nn2.language_name, lc.name, '') as anglicized_name,
        coalesce(cc.code, ''),
        nullif(nn1.native_name, '') as nn1name,
        nn1.id,
@@ -43,29 +45,44 @@ left join imports_ethnologuecountrycode cc on lc.country_code = cc.code
  where lc.status = %s or lc.status is NULL order by code;
 """, [EthnologueLanguageCode.STATUS_LIVING])
     rows = cursor.fetchall()
-    rows.extend([(x.merge_code(), x.merge_name(), None, "", None, "", None, "!ADDL", x.id, x.three_letter) for x in AdditionalLanguage.objects.all()])
+    rows.extend([
+        (
+            x.merge_code(), x.merge_name(), x.native_name, None, "", None, "",
+            None, "!ADDL", x.id, x.three_letter
+        )
+        for x in AdditionalLanguage.objects.all()
+    ])
     rows.sort()
     for r in rows:
         if r[0] is not None:
             language, _ = Language.objects.get_or_create(code=r[0])
             language.name = r[1]
-            if r[1] == r[3]:
-                language.source = WikipediaISOLanguage.objects.get(pk=r[4])
-            if r[1] == r[5]:
-                language.source = WikipediaISOLanguage.objects.get(pk=r[6])
-            if r[1] == r[7]:
-                language.source = SIL_ISO_639_3.objects.get(pk=r[8])
-            if r[7] == "!ADDL":
-                language.source = AdditionalLanguage.objects.get(pk=r[8])
-            if r[9] != "":
-                language.iso_639_3 = r[9]
+            language.anglicized_name = r[2]
+            if r[1] == r[4]:
+                language.source = WikipediaISOLanguage.objects.get(pk=r[5])
+            if r[1] == r[6]:
+                language.source = WikipediaISOLanguage.objects.get(pk=r[7])
+            if r[1] == r[8]:
+                language.source = SIL_ISO_639_3.objects.get(pk=r[9])
+            if r[8] == "!ADDL":
+                language.source = AdditionalLanguage.objects.get(pk=r[9])
+            if r[10] != "":
+                language.iso_639_3 = r[10]
             language.save()
-            if r[2]:
-                language.country = next(iter(Country.objects.filter(code=r[2])), None)
-                language.source = EthnologueCountryCode.objects.get(code=r[2])
+            if r[3]:
+                language.country = next(iter(Country.objects.filter(code=r[3])), None)
+                language.source = EthnologueCountryCode.objects.get(code=r[3])
                 language.save()
     languages_integrated.send(sender=Language)
     log(user=None, action="INTEGRATED_SOURCE_DATA", extra={})
+
+
+def _get_or_create_object(model, slug, name):
+    o, c = model.objects.get_or_create(slug=slug)
+    if c:
+        o.name = name
+        o.save()
+    return o
 
 
 @task()
@@ -82,14 +99,6 @@ def update_countries_from_imports():
             country.name = wcountry.english_short_name
         country.alpha_3_code = wcountry.alpha_3
         country.save()
-
-
-def _get_or_create_object(model, slug, name):
-    o, c = model.objects.get_or_create(slug=slug)
-    if c:
-        o.name = name
-        o.save()
-    return o
 
 
 @task()

--- a/td/templates/resources/language_detail.html
+++ b/td/templates/resources/language_detail.html
@@ -20,6 +20,9 @@
         <table class="table">
             <tbody>
                 <tr><th>Code</th><td>{{ language.code }}</td></tr>
+                {% if language.anglicized_name %}
+                <tr><th>Anglicized Name</th><td>{{ language.anglicized_name }}</td></tr>
+                {% endif %}
                 <tr><th>ISO 639-3</th><td>{{ language.iso_639_3 }}</td></tr>
                 <tr><th>Direction</th><td><span class="label label-default">{{ language.get_direction_display }}</span></td></tr>
                 <tr><th>Gateway Language</th><td>{{ language.gateway_language }}</td></tr>

--- a/td/templates/resources/language_list.html
+++ b/td/templates/resources/language_list.html
@@ -11,11 +11,11 @@
                     <th>Code</th>
                     <th>ISO-639-3</th>
                     <th>Name</th>
-                    <th>Direction</th>
+                    <th>Anglicized Name</th>
                     <th>Country</th>
                     <th># Native Speakers</th>
                     <th>Gateway Language</th>
-                    <th>Gateway Flag</th>
+                    <th>GW</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Addresses issues #56, #304

* Adds `anglicized_name` field to the Language model
* Populates `anglicized_name` during `integrate_imports` task
* Adds `ang` field populated with the anglicized name to the langnames.json export
* Adds `ang` to list of queried fields in the `languages_autocomplete` json view
* Adds `anglicized_name` to the list of editable fields in the Language model
* Adds `anglicized_name` to the Language details views
* Replaces Direction column in the uW > Languages report with the anglicized_name