### PR TITLE
Add countries to languages

### DIFF
--- a/td/models.py
+++ b/td/models.py
@@ -170,6 +170,12 @@ class Language(models.Model):
         return ""
 
     @property
+    def cc_all(self):
+        pks = [int(pk) for pk in self.attributes.filter(attribute="country_id").values_list("value", flat=True)]
+        countries = Country.objects.filter(pk__in=pks)
+        return [c.code.encode("utf-8") for c in countries]
+
+    @property
     def lr(self):
         if self.country and self.country.region:
             return self.country.region.name.encode("utf-8")
@@ -204,7 +210,7 @@ class Language(models.Model):
     @classmethod
     def names_data(cls):
         return [
-            dict(pk=x.pk, lc=x.lc, ln=x.ln, ang=x.ang, cc=[x.cc], lr=x.lr, gw=x.gateway_flag, ld=x.get_direction_display())
+            dict(pk=x.pk, lc=x.lc, ln=x.ln, ang=x.ang, cc=x.cc_all, lr=x.lr, gw=x.gateway_flag, ld=x.get_direction_display())
             for x in cls.objects.all().order_by("code")
         ]
 

--- a/td/resources/receivers.py
+++ b/td/resources/receivers.py
@@ -23,7 +23,7 @@ def handle_entity_save(sender, instance, *args, **kwargs):
     if sender in ENTITIES:
         if getattr(instance, "source", None) is not None:
             for attribute in instance.tracker.changed().keys():
-                instance.attributes.create(
+                instance.attributes.get_or_create(
                     attribute=attribute,
                     value=getattr(instance, attribute) or "",
                     source_ct=ContentType.objects.get_for_model(instance.source),

--- a/td/tasks.py
+++ b/td/tasks.py
@@ -123,3 +123,13 @@ def integrate_imb_language_data():
                     resource.published_flag = True
                     resource.save()
                     resource.medias.add(media)
+    for imb in IMBPeopleGroup.objects.order_by("language"):
+        language = next(iter(Language.objects.filter(iso_639_3=imb.rol)), None)
+        if not language:
+            language = next(iter(Language.objects.filter(code=imb.rol)), None)
+        if language:
+            country = next(iter(Country.objects.filter(name=imb.country)), None)
+            if country is not None:
+                language.country = country
+                language.source = imb
+                language.save()

--- a/td/tests/test_models.py
+++ b/td/tests/test_models.py
@@ -90,7 +90,7 @@ class LanguageIntegrationTests(TestCase):
         self.assertEquals(langs["kmg"]["lr"], "Pacific")
         self.assertEquals(langs["kmg"]["ld"], "ltr")
         self.assertTrue("es-419" in langs)
-        self.assertEquals(langs["es-419"]["cc"], [""])
+        self.assertEquals(langs["es-419"]["cc"], [])
         self.assertEquals(langs["es-419"]["ln"], u"Espa\xf1ol Latin America")
         self.assertEquals(langs["es-419"]["lr"], "")
         self.assertEquals(langs["es-419"]["ld"], "ltr")


### PR DESCRIPTION
![screen shot 2015-12-11 at 6 02 57 pm](https://cloud.githubusercontent.com/assets/1192/11758513/8eccdfde-a031-11e5-97fe-b47168185d94.png)

This is based off of data in the IMB data.

There is a caveat to this data and that is they do not use ethnologue country codes but names and a handful do not match, which means we currently can't list these countries with a language. The countries in question are:

```
td=# select distinct country from imports_imbpeoplegroup where country not in (select name from uw_country);
        country        
-----------------------
 Côte d'Ivoire
 Reunion
 Vietnam
 Sao Tome and Principe
 Russia
 Cabo Verde
 Svalbard
 Pitcairn Islands
 Timor-Leste
 Falkland Islands
 Taiwan
 Kosovo
 Saint Helena
 Congo, D.R.
 West Bank
 Gaza Strip
 Curaçao
```

This is either due to variants in spelling, or some countries just not existing in ethnologue (e.g. West Bank).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/329)
<!-- Reviewable:end -->
