### PR TITLE
Fix bug in PublishRequestNoAuthForm

### DIFF
--- a/td/publishing/forms.py
+++ b/td/publishing/forms.py
@@ -169,10 +169,12 @@ class PublishRequestForm(forms.ModelForm):
             except:
                 pass
 
-        self.fields['rejected_at'].widget.attrs['readonly'] = True
-        self.fields['rejected_at'].widget.attrs['disabled'] = 'disabled'
-        self.fields['rejected_by'].widget.attrs['readonly'] = True
-        self.fields['rejected_by'].widget.attrs['disabled'] = 'disabled'
+        # these fields are not present when the user is creating a new publish request
+        if 'rejected_at' in self.fields:
+            self.fields['rejected_at'].widget.attrs['readonly'] = True
+            self.fields['rejected_at'].widget.attrs['disabled'] = 'disabled'
+            self.fields['rejected_by'].widget.attrs['readonly'] = True
+            self.fields['rejected_by'].widget.attrs['disabled'] = 'disabled'
 
     def clean_language(self):
         lang_id = self.cleaned_data["language"]

--- a/td/tests/publishing/test_forms.py
+++ b/td/tests/publishing/test_forms.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 
 from td.publishing.models import RecentCommunication, Contact
-from td.publishing.forms import RecentComForm
+from td.publishing.forms import RecentComForm, PublishRequestForm, PublishRequestNoAuthForm
 
 
 class RecentComFormTestCase(TestCase):
@@ -51,3 +51,17 @@ class RecentComFormTestCase(TestCase):
             form.cleaned_data["communication"],
             "New communication message"
         )
+
+
+class PublishRequestFormNewRequestTestCase(TestCase):
+
+    def test_rejected_fields(self):
+        form = PublishRequestNoAuthForm({}, None)
+        self.assertFalse('rejected_at' in form.fields)
+
+
+class PublishRequestFormEditRequestTestCase(TestCase):
+
+    def test_rejected_fields(self):
+        form = PublishRequestForm({}, None)
+        self.assertTrue('rejected_at' in form.fields)


### PR DESCRIPTION
The rejected_at and rejected_by fields are not present when the user is creating a new PublishRequest.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/410)
<!-- Reviewable:end -->
