### PR TITLE
Language name in GL tracker is now a clickable link (Issue 446)

### DIFF
--- a/td/templates/gl_tracking/_phase_view.html
+++ b/td/templates/gl_tracking/_phase_view.html
@@ -58,7 +58,7 @@
             <div class="panel panel-default">
 
                 <!-- PANEL/TABLE HEADING -->
-                <div class="panel-heading collapsed clickable" data-toggle="collapse" data-target="#{{ language.code }}">
+                <div class="panel-heading collapsed" >
                     <span class="pull-right">
                         {% if phase == "1" %}
                             {{ language.progress_phase_1 }}%
@@ -68,7 +68,8 @@
                     </span>
                     <div style="display: flex;">
                         <h1 class="panel-title">
-                            {{ language.ang|default:language.ln }} <span class="badge">{{ language.code }}</span>
+                            <button class="icon-button" data-toggle="collapse" data-target="#{{ language.code }}" title="Expand/Collapse" data-tooltip><i class="fa fa-compress"></i></button>
+                            <a onclick="event.stopPropagation()" href="{% url "language_detail" language.pk %}">{{ language.ang|default:language.ln }}</a> <span class="badge">{{ language.code }}</span>
                             {% for variant in language.variant_codes %}
                                 <span class="badge">{{ variant }}</span>
                             {% endfor %}

--- a/td/templates/gl_tracking/dashboard.html
+++ b/td/templates/gl_tracking/dashboard.html
@@ -85,7 +85,7 @@
             display: inline;
         }
         .icon-button {
-            margin-left: 0.5rem;
+            margin-right: 0.5rem;
             line-height: 0;
         }
         th {


### PR DESCRIPTION
Squashed Commits:

Don't bubble clicking on the name
Moved the expand and collapse to a button instead of the header

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/499)
<!-- Reviewable:end -->
