### PR TITLE
Fix problem with storing the wrong GL Director name

### DIFF
--- a/td/templates/gl_tracking/_phase_view.html
+++ b/td/templates/gl_tracking/_phase_view.html
@@ -84,9 +84,9 @@
                 <!-- PANEL/TABLE BODY -->
                 <div id="{{ language.code }}" class="panel-body language-panel-body collapse">
                     {% if phase == "1" %}
-                        {% include "gl_tracking/_language_doc_table.html" with region=language.wa_region documents=language.documents_phase_1 can_edit=can_edit %}
+                        {% include "gl_tracking/_language_doc_table.html" with region=language.wa_region.slug documents=language.documents_phase_1 can_edit=can_edit %}
                     {% elif phase == "2" %}
-                        {% include "gl_tracking/_language_doc_table.html" with region=language.wa_region documents=language.documents_phase_2 can_edit=can_edit %}
+                        {% include "gl_tracking/_language_doc_table.html" with region=language.wa_region.slug documents=language.documents_phase_2 can_edit=can_edit %}
                     {% endif %}
                 </div>
 

--- a/td/templates/gl_tracking/region_assignment_modal_form.html
+++ b/td/templates/gl_tracking/region_assignment_modal_form.html
@@ -40,14 +40,14 @@
                         <td>
                             <select id="{{ region.slug }}_director" name="{{ region.slug }}_director" class="form-control select2-multiple" multiple="multiple">
                                 {% for director in gl_directors %}
-                                    <option value="{{ director.name }}" {% if director.name in region.gl_directors %}selected="true"{% endif %}>{{ director.name }}</option>
+                                    <option value="{{ director.user.username }}" {% if director.name in region.gl_directors %}selected="true"{% endif %}>{{ director.name }}</option>
                                 {% endfor %}
                             </select>
                         </td>
                         <td>
                             <select id="{{ region.slug }}_helper" name="{{ region.slug }}_helper" class="form-control select2-multiple" multiple="multiple">
                                 {% for helper in gl_helpers %}
-                                    <option value="{{ helper.name }}" {% if helper.name in region.gl_helpers %}selected="true"{% endif %}>{{ helper.name }}</option>
+                                    <option value="{{ helper.user.username }}" {% if helper.name in region.gl_helpers %}selected="true"{% endif %}>{{ helper.name }}</option>
                                 {% endfor %}
                             </select>
                         </td>


### PR DESCRIPTION
Only use GLDirector.name to display the name, not to store it. Keep
using the user.username for the backend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/538)
<!-- Reviewable:end -->
