### PR TITLE
Fix error when searching with a dash from the homepage

### DIFF
--- a/td/urls_languages.py
+++ b/td/urls_languages.py
@@ -54,7 +54,7 @@ urlpatterns = [
     url(r"countries/(?P<pk>\d+)/languages/create/$", LanguageCreateView.as_view(), name="language_create"),
 
     url(r"ajax/languages/$", AjaxLanguageListView.as_view(), name="ajax_ds_uw_languages"),
-    url(r"ajax/languages/(?P<q>[\w\d ]+)/$", AjaxLanguageListView.as_view(), name="ajax_ds_uw_languages"),
+    url(r"ajax/languages/(?P<q>.*)/$", AjaxLanguageListView.as_view(), name="ajax_ds_uw_languages"),
     url(r"ajax/languages_gateway/(?P<pk>\d+)/$", AjaxLanguageGatewayListView.as_view(), name="ajax_ds_uw_languages_gateway"),
 
     url(r"^languages/$", LanguageListView.as_view(), name="language_list"),


### PR DESCRIPTION
Resolves #544 

Wrong regex in the urlpattern cause mismatch for url that contains one
or more dash in the search term.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/545)
<!-- Reviewable:end -->
