### PR TITLE
Fix error in DataTableSourceView.format_row()

### DIFF
--- a/td/utils.py
+++ b/td/utils.py
@@ -277,13 +277,13 @@ class DataTableSourceView(View):
                             row.append('<a href="{0}">{1}</a>'.format(reverse(
                                 self.link_url_name,
                                 kwargs={"pk": getattr(obj, self.link_url_field)}),
-                                str(v).encode("utf-8")
+                                v.encode("utf-8") if hasattr(v, "encode") else v
                             ))
                         else:
                             row.append('<a href="{0}">{1}</a>'.format(reverse(
                                 self.link_url_name,
                                 kwargs={self.link_url_field: getattr(obj, self.link_url_field)}),
-                                str(v).encode("utf-8")
+                                v.encode("utf-8") if hasattr(v, "encode") else v
                             ))
                     else:
                         row.append(v)


### PR DESCRIPTION
The error occurs when it's trying to encode an integer. Put a check so
it encodes only if it has the "encode" attribute.

Resolves #595

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/596)
<!-- Reviewable:end -->
