### PR TITLE
Enable Celerybeat

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: gunicorn --bind=0.0.0.0 --log-file - td.wsgi
+worker: celery worker --app=td --concurrency=4 --pool=prefork --no-color

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn --bind=0.0.0.0 --log-file - td.wsgi
-worker: celery worker --app=td --concurrency=4 --pool=prefork --no-color
+worker: celery worker --app=td --concurrency=4 --pool=prefork --no-color --loglevel=info --beat

--- a/gondor.yml
+++ b/gondor.yml
@@ -1,7 +1,4 @@
 site: eldarion-clients-uw/td
-exec:
-    web: gunicorn --bind=0.0.0.0 --log-file - td.wsgi
-    worker: celery worker --app=td --concurrency=4 --loglevel=WARNING --pool=prefork --no-color
 branches:
   master: primary
   develop: demo 


### PR DESCRIPTION
This PR enables Celerybeat on the Celery worker to process periodic tasks.

It also moves process definition out of `gondor.yml` to a `Procfile`.  Among other things, using a `Procfile` makes it easier to run the project locally using tools such as [Foreman](https://github.com/ddollar/foreman) or [Honcho](https://github.com/nickstenning/honcho).

In the future, if the `worker` service is scaled to more than one replica, add [a separate `scheduler` service to handle Celerybeat](http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#starting-the-scheduler):

```
# Procfile
worker: celery worker --app=td --concurrency=4 --pool=prefork --no-color --loglevel=info
scheduler: celery beat --app=td --loglevel=info
```

cc: @vleong2332

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/631)
<!-- Reviewable:end -->
