### PR TITLE
Remove login requirement for AjaxTemporaryCode

### DIFF
--- a/td/views.py
+++ b/td/views.py
@@ -776,7 +776,7 @@ class AjaxTempLanguageListView(TempLanguageTableSourceView):
     link_url_field = "pk"
 
 
-class AjaxTemporaryCode(LoginRequiredMixin, View):
+class AjaxTemporaryCode(View):
 
     def get(self, request, *args, **kwargs):
         return HttpResponse(self.generate_temp_code())


### PR DESCRIPTION
The login requirement is deemed unnecessary at this point. The access is
needed for the development of an internal project management system.

I believe this won't have any impact to security since all the view
does is spit out a string of temporary code that's not used already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/639)
<!-- Reviewable:end -->
