### PR TITLE
Limit gateway language field on language form to gateway languages (#…

### DIFF
--- a/td/forms.py
+++ b/td/forms.py
@@ -95,7 +95,7 @@ class LanguageForm(EntityTrackingForm):
             widget=forms.TextInput(
                 attrs={
                     "class": "language-selector",
-                    "data-source-url": reverse("names_autocomplete")
+                    "data-source-url": reverse("gateway_languages")
                 }
             ),
             required=False

--- a/td/models.py
+++ b/td/models.py
@@ -453,6 +453,10 @@ class Language(CommentableModel):
                                 gw=x.gateway_flag, ld=x.get_direction_display()))
         return data
 
+    @classmethod
+    def get_gateway_languages(cls):
+        return [dict(pk=x.pk, lc=x.lc, ln=x.ln, ang=x.ang, lr=x.lr) for x in cls.objects.filter(gateway_flag=True)]
+
 
 class EAVBase(models.Model):
     attribute = models.CharField(max_length=100)

--- a/td/tests/test_models.py
+++ b/td/tests/test_models.py
@@ -375,6 +375,17 @@ class LanguageTestCase(TestCase):
         expected_result = ", ".join([alt_1.name, alt_2.name])
         self.assertEqual(self.lang.tag_tip, expected_result)
 
+    def test_get_gateway_languages(self):
+        other_language = Language.objects.create(code="ol", iso_639_3="tol", name="Test Other Language",
+                                                 gateway_flag=False)
+        result = Language.get_gateway_languages()
+        expected_gateway_language = dict(pk=self.lang.pk, lc=self.lang.lc, ln=self.lang.ln, ang=self.lang.ang,
+                                         lr=self.lang.lr)
+        expected_other_language = dict(pk=other_language.pk, lc=other_language.lc, ln=other_language.ln,
+                                       ang=other_language.ang, lr=other_language.lr)
+        self.assertIn(expected_gateway_language, result)
+        self.assertNotIn(expected_other_language, result)
+
 
 class CountryTestCase(TestCase):
 

--- a/td/tests/test_views.py
+++ b/td/tests/test_views.py
@@ -4,6 +4,8 @@ import importlib
 import re
 import types
 import requests
+import json
+from absoluteuri import reverse
 
 from mock import patch, Mock
 
@@ -18,7 +20,7 @@ from ..models import TempLanguage, Language
 from ..resources.models import Questionnaire
 from ..views import TempLanguageListView, TempLanguageDetailView, TempLanguageUpdateView, AjaxTemporaryCode,\
     TempLanguageAdminView, TempLanguageWizardView, LanguageDetailView, codes_text_export, names_text_export,\
-    names_json_export
+    names_json_export, gateway_languages_autocomplete
 from ..forms import TempLanguageForm
 from ..tests.models import NoSignalTestCase
 
@@ -308,3 +310,53 @@ class TempLanguageAdminViewTestCase(TestCase):
         TempLanguage.objects.create(pk=999, code="abc")
         returned = self.view.get_context_data()
         self.assertIn("pending", returned)
+
+
+class GatewayLanguagesAutocompleteTestCase(TestCase):
+    def setUp(self):
+        self.request = RequestFactory().get(reverse("gateway_languages"))
+        self.ol = Language.objects.create(code="ol", iso_639_3="tol", name="Test Other Language",
+                                          gateway_flag=False)
+        self.gl = Language.objects.create(code="gl", iso_639_3="tgl", name="Test Gateway Language",
+                                          gateway_flag=True)
+
+    def test_returns_json(self):
+        """
+        Must return JsonResponse with results, count, and term
+        """
+        response = gateway_languages_autocomplete(self.request)
+        self.assertIsInstance(response, JsonResponse)
+        self.assertIn("results", response.content)
+        self.assertIn("count", response.content)
+        self.assertIn("term", response.content)
+
+    @patch("td.views.Language.get_gateway_languages")
+    def test_call_get_gateway_languages(self, mock_get_gateway_languages):
+        gateway_languages_autocomplete(self.request)
+        mock_get_gateway_languages.assert_called_once_with()
+
+    def test_search_other_language(self):
+        """
+        Should not return any languages
+        """
+        term = "ol"
+        expected_results = []
+        request = RequestFactory().get("/ac/gateway-langnames/?q=" + term)
+        response = gateway_languages_autocomplete(request)
+        data = json.loads(response.content)
+        self.assertListEqual(data.get("results"), expected_results)
+        self.assertEqual(data.get("term"), "ol")
+        self.assertEqual(data.get("count"), 0)
+
+    def test_search_gateway_language(self):
+        """
+        Should return one gateway language
+        """
+        term = "gl"
+        expected_results = [dict(pk=self.gl.pk, lc=self.gl.lc, ln=self.gl.ln, lr=self.gl.lr, ang=self.gl.ang)]
+        request = RequestFactory().get("/ac/gateway-langnames/?q=" + term)
+        response = gateway_languages_autocomplete(request)
+        data = json.loads(response.content)
+        self.assertListEqual(data.get("results"), expected_results)
+        self.assertEqual(data.get("term"), term)
+        self.assertEqual(data.get("count"), 1)

--- a/td/urls.py
+++ b/td/urls.py
@@ -25,6 +25,7 @@ from .views import (
     names_json_export,
     export_svg,
     languages_autocomplete,
+    gateway_languages_autocomplete,
 )
 
 urlpatterns = [
@@ -64,6 +65,7 @@ urlpatterns = [
     url(r"^ajax/data-sources/imb/peoplegroups/$", AjaxIMBPeopleGroupListView.as_view(), name="ajax_ds_imb_peoplegroups"),
 
     url(r"^ac/langnames/", languages_autocomplete, name="names_autocomplete"),
+    url(r"^ac/gateway-langnames/", gateway_languages_autocomplete, name="gateway_languages")
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/td/views.py
+++ b/td/views.py
@@ -112,6 +112,33 @@ def languages_autocomplete(request):
     return JsonResponse({"results": d, "count": len(d), "term": term})
 
 
+# TODO: Like languages_autocomplete() but only for gateway languages. Candidate for refactor.
+def gateway_languages_autocomplete(request):
+    term = request.GET.get("q", "")
+    data = Language.get_gateway_languages()
+    d = []
+    term = term.lower().encode("utf-8")
+    if len(term) <= 3:
+        # search: lc
+        # first do a *starts with* style search of language code (lc)
+        d.extend([
+            x
+            for x in data
+            if term == x["lc"].lower()[:len(term)]
+        ])
+    if len(term) >= 3:
+        # search: lc, ln, lr, ang
+        d.extend([
+            x
+            for x in data
+            if (
+                term in x["lc"] or term in x["ln"].lower() or
+                term in x["ang"].lower() or term in x["lr"].lower()
+            )
+        ])
+    return JsonResponse({"results": d, "count": len(d), "term": term})
+
+
 class AdditionalLanguageListView(TemplateView):
     template_name = "td/additionallanguage_list.html"
 


### PR DESCRIPTION
…655)

* Limit gateway language field on language form to gateway languages

When selecting a language's gateway language, we only want to show
gateway languages instead of all languages.

Filtering out other languages also will help avoid a situation where a
temporary language has another (unapproved) temporary language as its
gateway language.

* Add unit tests for gateway language autocomplete

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/656)
<!-- Reviewable:end -->
