### PR TITLE
Add healthcheck endpoint for Celery periodic tasks

### DIFF
--- a/td/api/urls.py
+++ b/td/api/urls.py
@@ -1,6 +1,12 @@
 from django.conf.urls import url
 
-from .views import QuestionnaireView, templanguages_json, lang_assignment_json, lang_assignment_changed_json
+from .views import (
+    celerybeat_healthz,
+    lang_assignment_changed_json,
+    lang_assignment_json,
+    QuestionnaireView,
+    templanguages_json
+)
 
 
 urlpatterns = [
@@ -8,4 +14,5 @@ urlpatterns = [
     url(r"^templanguages/$", templanguages_json, name="templanguages"),
     url(r"^templanguages/assignment/$", lang_assignment_json, name="templanguages_assignment"),
     url(r"^templanguages/assignment/changed/$", lang_assignment_changed_json, name="templanguages_changed"),
+    url(r"^celerybeat/healthz/$", celerybeat_healthz),
 ]

--- a/td/api/views.py
+++ b/td/api/views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from django.conf import settings
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
@@ -113,6 +114,9 @@ def lang_assignment_changed_json(request):
 
 
 def celerybeat_healthz(request):
+    if request.GET.get("key") != settings.CELERYBEAT_HEALTHZ_AUTH_KEY:
+        return JsonResponse({"message": "Not authorized."}, status=403)
+
     succesful_tasks = []
     failing_tasks = []
 

--- a/td/api/views.py
+++ b/td/api/views.py
@@ -121,8 +121,8 @@ def celerybeat_healthz(request):
     failing_tasks = []
 
     next_sixty_seconds = -60
-    for task in PeriodicTask.objects.filter(enabled=True).order_by("?"):
-        # retrieve the estimated number of seconds until the next time the task should be rans
+    for task in PeriodicTask.objects.filter(enabled=True):
+        # retrieve the estimated number of seconds until the next time the task should be ran
         seconds_until_next_execution = task.schedule.remaining_estimate(task.last_run_at).total_seconds()
         if seconds_until_next_execution > next_sixty_seconds:
             succesful_tasks.append(task.name)

--- a/td/api/views.py
+++ b/td/api/views.py
@@ -120,11 +120,12 @@ def celerybeat_healthz(request):
     succesful_tasks = []
     failing_tasks = []
 
-    next_sixty_seconds = -60
+    past_sixty_seconds = -60
     for task in PeriodicTask.objects.filter(enabled=True):
         # retrieve the estimated number of seconds until the next time the task should be ran
         seconds_until_next_execution = task.schedule.remaining_estimate(task.last_run_at).total_seconds()
-        if seconds_until_next_execution > next_sixty_seconds:
+
+        if seconds_until_next_execution > past_sixty_seconds:
             succesful_tasks.append(task.name)
         else:
             # the task should have been scheduled already

--- a/td/api/views.py
+++ b/td/api/views.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
-from django.utils import timezone
 
 from djcelery.models import PeriodicTask
 
@@ -130,7 +129,7 @@ def celerybeat_healthz(request):
         else:
             # the task should have been scheduled already
             failing_tasks.append(task.name)
-    
+
     healthy = True
     status_code = 200
     if failing_tasks:
@@ -138,8 +137,8 @@ def celerybeat_healthz(request):
         status_code = 503
 
     data = {
-        "healthy": healthy, 
+        "healthy": healthy,
         "failing": failing_tasks,
-        "succesful": succesful_tasks, 
+        "succesful": succesful_tasks,
     }
     return JsonResponse(data, status=status_code)

--- a/td/settings.py
+++ b/td/settings.py
@@ -256,6 +256,7 @@ CELERYBEAT_SCHEDULER = "djcelery.schedulers.DatabaseScheduler"
 CELERY_TASK_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']   # for security reasons, don't allow pickle
 CELERY_RESULT_BACKEND = "redis://"
+CELERYBEAT_HEALTHZ_AUTH_KEY = os.environ.get("CELERYBEAT_HEALTHZ_AUTH_KEY", "celerybeat-healthz")
 
 REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,


### PR DESCRIPTION
Adds `celerybeat_healthz` view that checks to see if Celerybeat tasks are running as expected.

The `CELERYBEAT_HEALTHZ_AUTH_KEY` environment variable can be used to restrict access to this endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/658)
<!-- Reviewable:end -->
