### PR TITLE
Store the results because otherwise it is too slow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,17 @@ After installing requirements (via pip) within your environment or virtualenv:
 * `python manage.py reload_imports`
 
 At this point, the basic country and language datasets will be populated but without many optional fields or extra data.
+
+### Updating the `/exports/langnames.json` and `/exports/langnames_short.json` endpoints
+
+When languages are added or updated, run this command to update the data locally:
+
+```bash
+python manage.py rebuild_langnames
+```
+
+Switch to the master branch and run this command to update the data on the server:
+
+```bash
+ec run web python manage.py rebuild_langnames
+```

--- a/td/imports/management/commands/rebuild_langnames.py
+++ b/td/imports/management/commands/rebuild_langnames.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+from td.tasks import update_langnames_data
+
+
+class Command(BaseCommand):
+    help = "rebuild langnames and langnames_short in the table td_jsondata"
+
+    def handle(self, *args, **options):
+        update_langnames_data()

--- a/td/tasks.py
+++ b/td/tasks.py
@@ -77,6 +77,10 @@ def update_langnames_data():
     langnames.data = Language.names_data()
     langnames.save()
 
+    shorter, created = JSONData.objects.get_or_create(name="langnames_short")
+    shorter.data = Language.names_data(True)
+    shorter.save()
+
 
 @task()
 def reset_langnames_cache(short=False):

--- a/td/tests/test_tasks.py
+++ b/td/tests/test_tasks.py
@@ -97,6 +97,7 @@ class UpdateLangnamesDataTestCase(TestCase):
         self.assertIn("lr", json)
         self.assertIn("gw", json)
         self.assertIn("ld", json)
+        self.assertIn("hc", json)
 
 
 class PostToExtAppTestCase(TestCase):

--- a/td/tests/test_views.py
+++ b/td/tests/test_views.py
@@ -88,13 +88,13 @@ class NamesJsonExportTestCase(TestCase):
 
 class NamesJsonExportShortTestCase(TestCase):
 
-    @patch("td.models.Language.names_data")
-    def test_return_json(self, mock_lang_names_data):
-        mock_lang_names_data.return_value = [dict(pk=1, lc="en", ln="English", ang="English", lr="Europe", hc="GB")]
+    @patch("td.models.JSONData.objects.get")
+    def test_return_json(self, mock_jsondata_get):
+        mock_jsondata_get.return_value.data = [dict(pk=1, lc="en", ln="English", ang="English", lr="Europe", hc="GB")]
         response = names_json_export_short(None)
 
-        # Must call Language.names_data(True)
-        mock_lang_names_data.assert_called_once_with(True)
+        # Must call JSONData.objects.get(name="langnames_short")
+        mock_jsondata_get.assert_called_once_with(name="langnames_short")
 
         # Must return JsonResponse
         self.assertIsInstance(response, JsonResponse)

--- a/td/views.py
+++ b/td/views.py
@@ -61,11 +61,11 @@ def names_json_export(request):
 
 def names_json_export_short(request):
 
-    # NOTE: This is the direct, synchronous way
-    data = Language.names_data(True)
+    # NOTE: This is the DB/management command way
+    langnames = JSONData.objects.get(name="langnames_short")
 
     # Set safe to False to allow list instead of dict to be returned
-    return JsonResponse(data, safe=False)
+    return JsonResponse(langnames.data, safe=False)
 
 
 @csrf_exempt
@@ -96,9 +96,7 @@ def get_langnames(short=False):
 
 def languages_autocomplete(request):
     term = request.GET.get("q").lower()
-    # Using `Language.names_data(True)` because `get_langnames(short=True)` produces inconsistent results
-    # data = get_langnames(short=True)
-    data = Language.names_data(True)
+    data = get_langnames(short=True)
     d = []
     if len(term) <= 3:
         term = term.encode("utf-8")


### PR DESCRIPTION
Also added a management command to update the stored langnames

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationdatabaseweb/660)
<!-- Reviewable:end -->
