### PR TITLE
Add CORS_ALLOW_CREDENTIALS

### DIFF
--- a/td/settings.py
+++ b/td/settings.py
@@ -283,6 +283,8 @@ CORS_ALLOW_ALL_ORIGINS_PATH_REGEX_WHITELIST = [
     r"^/exports/*",
 ]
 
+CORS_ALLOW_CREDENTIALS = True
+
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration


### PR DESCRIPTION
Should resolve this issue:

```
/#?client_method=GET&client_credentials=true&server_url=https%3A%2F%2Ftd.unfoldingword.org%2Fexports%2Flangnames.json&server_enable=true&server_status=200&server_credentials=false&server_tabs=remote:1 Access to XMLHttpRequest at 'https://td.unfoldingword.org/exports/langnames.json' from origin 'https://www.test-cors.org' has been blocked by CORS policy: The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
```

refs https://github.com/adamchainz/django-cors-headers/tree/f29997e958becf4f1f7b730475e68566b08d62de#cors_allow_credentials